### PR TITLE
Fix design name casing in parameters for construct function

### DIFF
--- a/designs/cgra/construct-open.py
+++ b/designs/cgra/construct-open.py
@@ -24,7 +24,7 @@ def construct():
 
   parameters = {
     'construct_path' : __file__,
-    'design_name'    : 'CGRATemplateRTL',
+    'design_name'    : 'CgraTemplateRTL',
     'clock_period'   : 2.0,
     'adk'            : adk_name,
     'adk_view'       : adk_view,


### PR DESCRIPTION
According to the name changed: https://github.com/tancheng/VectorCGRA/blob/master/cgra/CgraTemplateRTL.py
